### PR TITLE
update regex to only look for the todos and not the comment prefix for various languages

### DIFF
--- a/todos/todos.go
+++ b/todos/todos.go
@@ -19,7 +19,7 @@ type Comment struct {
 
 func Search(dir string, commentTypes []string, ignores []string) ([]Comment, error) {
 	// Define regular expression to match the specified comment types
-	commentRegex := regexp.MustCompile(fmt.Sprintf(`(?i)//\s*(%s)(?:\(([\w.-]+)\))?:\s*(.*)`, strings.Join(commentTypes, "|")))
+	commentRegex := regexp.MustCompile(fmt.Sprintf(`(?i)\s*(%s)(?:\(([\w.-]+)\))?:\s*(.*)`, strings.Join(commentTypes, "|")))
 
 	// Create a slice to hold the comments
 	comments := []Comment{}


### PR DESCRIPTION
Removing matching for `//` to allow it to work with many languages and comment types